### PR TITLE
Update .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,5 @@ STRIPE_WEBHOOK_SECRET=whsec_1234
 
 # Environment variables 
 STATIC_DIR=../../client 
+BASE_PRICE=10000
+DOMAIN="http://localhost:4242"


### PR DESCRIPTION
code failed with below errors due to no BASE_PRICE and DOMAIN variables set in .env file

- (node:4665) UnhandledPromiseRejectionWarning: Error: Invalid integer: NaN
 
- (node:4815) UnhandledPromiseRejectionWarning: Error: Invalid URL: undefined/success.html?session_id={CHECKOUT_SESSION_ID}. URLs must begin with http or https.